### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/Miaxos/roster/compare/v0.1.2...v0.1.3) - 2024-02-02
+
+### Other
+- add a way to publish releases
+
 ## [0.1.2](https://github.com/Miaxos/roster/compare/v0.1.1...v0.1.2) - 2024-02-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "roster"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/app/roster/Cargo.toml
+++ b/app/roster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roster"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Replacement of Redis with Rust"
 authors = ["Anthony Griffon <anthony@griffon.one>"]


### PR DESCRIPTION
## 🤖 New release
* `roster`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/Miaxos/roster/compare/v0.1.2...v0.1.3) - 2024-02-02

### Other
- add a way to publish releases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).